### PR TITLE
fix D7ry/Valor#1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ if(NOT DEFINED CompiledPluginsPath)
 	message(FATAL_ERROR "CompiledPluginsPath is not set")
 endif()
 
+if (NOT DEFINED ENV{CommonLibSSEPath_NG})
+	message(FATAL_ERROR "CommonLibSSEPath_NG is not set")
+endif()
+
 option(COPY_OUTPUT "Copy the output of build operations to the game directory" ON)
 option(ENABLE_SKYRIM_SE "Enable support for Skyrim SE in the dynamic runtime feature." ON)
 option(ENABLE_SKYRIM_AE "Enable support for Skyrim AE in the dynamic runtime feature." ON)


### PR DESCRIPTION
Resolve `add_library cannot create target "Valor" because another target with the same name already exists` by adding check on envimantal variable CommonLibSSEPath_NG.